### PR TITLE
fix placeholder replacement in 'path'

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -277,7 +277,7 @@ class ImageSaver:
     ):
 
         filename = make_filename(filename, seed_value, modelname, counter, time_format, sampler_name, steps, cfg, scheduler, denoise)
-        path = make_pathname(path, seed_value, modelname, counter, time_format, sampler_name, steps, cfg, scheduler, denoise)
+        path = make_filename(path, seed_value, modelname, counter, time_format, sampler_name, steps, cfg, scheduler, denoise)
         ckpt_path = folder_paths.get_full_path("checkpoints", modelname)
         modelhash = get_sha256(ckpt_path)[:10]
         metadata_extractor = PromptMetadataExtractor([positive, negative])


### PR DESCRIPTION
Change function used in the assignment of 'path' from 'make_pathname' to 'make_filename' so that placeholders in folder names are actually replaced.

Currently, 'make_pathname' is used in the assignment of 'path' but it doesn't work as intended. Any placeholders, such as %date, %time, %model, etc., do not get replaced in 'path' and you end up with folder names like '%date'. If the 'make_filename' function is used instead, the placeholders in folder names are actually replaced.