### PR TITLE
Enhancement: Option for embedding prompt/workflow in PNG

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -250,6 +250,7 @@ class ImageSaver:
                 "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0}),
                 "time_format": ("STRING", {"default": "%Y-%m-%d-%H%M%S", "multiline": False}),
                 "save_workflow_as_json": ("BOOLEAN", {"default": False}),
+                "embed_workflow": ("BOOLEAN", {"default": True}),
             },
             "hidden": {
                 "prompt": "PROMPT",
@@ -287,6 +288,7 @@ class ImageSaver:
             time_format,
             denoise,
             save_workflow_as_json=False,
+            embed_workflow=True,
             prompt=None,
             extra_pnginfo=None,
     ):
@@ -315,12 +317,12 @@ class ImageSaver:
                 print(f'The path `{output_path.strip()}` specified doesn\'t exist! Creating directory.')
                 os.makedirs(output_path, exist_ok=True)
 
-        filenames = self.save_images(images, output_path, filename, comment, extension, quality_jpeg_or_webp, lossless_webp, optimize_png, prompt, extra_pnginfo, save_workflow_as_json)
+        filenames = self.save_images(images, output_path, filename, comment, extension, quality_jpeg_or_webp, lossless_webp, optimize_png, prompt, extra_pnginfo, save_workflow_as_json,embed_workflow)
 
         subfolder = os.path.normpath(path)
         return {"ui": {"images": map(lambda filename: {"filename": filename, "subfolder": subfolder if subfolder != '.' else '', "type": 'output'}, filenames)}}
 
-    def save_images(self, images, output_path, filename_prefix, comment, extension, quality_jpeg_or_webp, lossless_webp, optimize_png, prompt, extra_pnginfo, save_workflow_as_json) -> list[str]:
+    def save_images(self, images, output_path, filename_prefix, comment, extension, quality_jpeg_or_webp, lossless_webp, optimize_png, prompt, extra_pnginfo, save_workflow_as_json,embed_workflow) -> list[str]:
         img_count = 1
         paths = list()
         for image in images:
@@ -338,7 +340,7 @@ class ImageSaver:
 
                 if prompt is not None:
                     metadata.add_text("prompt", json.dumps(prompt))
-                if extra_pnginfo is not None:
+                if embed_workflow is True and extra_pnginfo is not None:
                     for x in extra_pnginfo:
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 

--- a/nodes.py
+++ b/nodes.py
@@ -339,8 +339,9 @@ class ImageSaver:
                 metadata.add_text("parameters", comment)
 
                 if prompt is not None:
+                    print(f'Prompt `{json.dumps(prompt)}`')
                     metadata.add_text("prompt", json.dumps(prompt))
-                if embed_workflow is True and extra_pnginfo is not None:
+                if embed_workflow and extra_pnginfo is not None:
                     for x in extra_pnginfo:
                         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 

--- a/nodes.py
+++ b/nodes.py
@@ -338,8 +338,7 @@ class ImageSaver:
                 metadata = PngInfo()
                 metadata.add_text("parameters", comment)
 
-                if prompt is not None:
-                    print(f'Prompt `{json.dumps(prompt)}`')
+                if embed_workflow and prompt is not None:
                     metadata.add_text("prompt", json.dumps(prompt))
                 if embed_workflow and extra_pnginfo is not None:
                     for x in extra_pnginfo:

--- a/nodes.py
+++ b/nodes.py
@@ -338,11 +338,13 @@ class ImageSaver:
                 metadata = PngInfo()
                 metadata.add_text("parameters", comment)
 
-                if embed_workflow and prompt is not None:
-                    metadata.add_text("prompt", json.dumps(prompt))
-                if embed_workflow and extra_pnginfo is not None:
-                    for x in extra_pnginfo:
-                        metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+                # embed workflow and prompt json only if embed_workflow is true
+                if embed_workflow:
+                    if prompt is not None:
+                        metadata.add_text("prompt", json.dumps(prompt))
+                    if extra_pnginfo is not None:
+                        for x in extra_pnginfo:
+                            metadata.add_text(x, json.dumps(extra_pnginfo[x]))
 
                 filename = f"{current_filename_prefix}.png"
                 img.save(os.path.join(output_path, filename), pnginfo=metadata, optimize=optimize_png)


### PR DESCRIPTION
Added optional parameter that can be used to enable or disabled the embedding of prompt/workflow details in PNG.

It's enabled by default.   One slight issue however is that the prompt details captured in the parameters doesn't contain the correct SEED if you are generating multiple images.   This occurs even if you embed the workflow.   The comment is only generated once and not per image.  Addressing this is beyond the scope of this change.  

![image](https://github.com/alexopus/ComfyUI-Image-Saver/assets/30253830/6b61634c-c253-46f5-84b7-399e3604e60e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to embed workflow and prompt JSON when saving files and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->