### PR TITLE
Add Civitai downloader node for complete metadata saving.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -131,7 +131,7 @@ class ImageSaver:
                 "embed_workflow_in_png": ("BOOLEAN", {"default": True,                                             "tooltip": "if True, embeds the workflow in the saved PNG files"}),
                 "additional_hashes":     ("STRING",  {"default": "", "multiline": False,                           "tooltip": "hashes separated by commas, optionally with names. 'Name:HASH' (e.g., 'MyLoRA:FF735FF83F98')\nWith download_civitai_data set to true, weights can be added as well. (e.g., 'HASH:Weight', 'Name:HASH:Weight')"}),
                 "download_civitai_data": ("BOOLEAN", {"default": True,                                             "tooltip": "Download and cache data from civitai.com to save correct metadata. Allows LoRA weights to be saved to the metadata."}),
-                "easy_remix": ("BOOLEAN", {"default": True,                                                        "tooltip": "Strip LoRAs and simplify 'embedding:path' from the prompt to make the Remix option on civitai.com more seamless."}),
+                "easy_remix":            ("BOOLEAN", {"default": True,                                             "tooltip": "Strip LoRAs and simplify 'embedding:path' from the prompt to make the Remix option on civitai.com more seamless."}),
             },
             "hidden": {
                 "prompt": "PROMPT",

--- a/nodes.py
+++ b/nodes.py
@@ -1,11 +1,14 @@
 import os
 from datetime import datetime
+from pathlib import Path
 import json
+import requests
 import piexif
 import piexif.helper
 from PIL import Image
 from PIL.PngImagePlugin import PngInfo
 import numpy as np
+import re
 import folder_paths
 from .utils import get_sha256
 from .prompt_metadata_extractor import PromptMetadataExtractor
@@ -126,7 +129,9 @@ class ImageSaver:
                 "time_format":           ("STRING",  {"default": "%Y-%m-%d-%H%M%S", "multiline": False,            "tooltip": "timestamp format"}),
                 "save_workflow_as_json": ("BOOLEAN", {"default": False,                                            "tooltip": "if True, also saves the workflow as a separate JSON file"}),
                 "embed_workflow_in_png": ("BOOLEAN", {"default": True,                                             "tooltip": "if True, embeds the workflow in the saved PNG files"}),
-                "additional_hashes":     ("STRING",  {"default": "", "multiline": False,                           "tooltip": "hashes separated by commas, optionally with names. 'Name:HASH' (e.g., 'MyLoRA:FF735FF83F98')"}),
+                "additional_hashes":     ("STRING",  {"default": "", "multiline": False,                           "tooltip": "hashes separated by commas, optionally with names. 'Name:HASH' (e.g., 'MyLoRA:FF735FF83F98')\nWith download_civitai_data set to true, weights can be added as well. (e.g., 'HASH:Weight', 'Name:HASH:Weight')"}),
+                "download_civitai_data": ("BOOLEAN", {"default": True,                                             "tooltip": "Download and cache data from civitai.com to save correct metadata. Allows LoRA weights to be saved to the metadata."}),
+                "easy_remix": ("BOOLEAN", {"default": True,                                                        "tooltip": "Strip LoRAs and simplify 'embedding:path' from the prompt to make the Remix option on civitai.com more seamless."}),
             },
             "hidden": {
                 "prompt": "PROMPT",
@@ -141,6 +146,12 @@ class ImageSaver:
 
     CATEGORY = "ImageSaver"
     DESCRIPTION = "Save images with civitai-compatible generation metadata"
+
+    # Match 'anything' or 'anything:anything' with trimmed white space
+    re_manual_hash = re.compile(r'^\s*([^:]+?)(?:\s*:\s*([^\s:][^:]*?))?\s*$')
+    # Match 'anything', 'anything:anything' or 'anything:anything:number' with trimmed white space
+    re_manual_hash_weights = re.compile(r'^\s*([^:]+?)(?:\s*:\s*([^\s:][^:]*?))?(?:\s*:\s*([-+]?(?:\d+(?:\.\d*)?|\.\d+)))?\s*$')
+    MAX_HASH_LENGTH = 16 # skip larger unshortened hashes, such as full sha256 or blake3
 
     def save_files(
         self,
@@ -168,6 +179,8 @@ class ImageSaver:
         additional_hashes="",
         save_workflow_as_json=False,
         embed_workflow_in_png=True,
+        download_civitai_data=False,
+        easy_remix=False,
         prompt=None,
         extra_pnginfo=None,
     ):
@@ -189,52 +202,115 @@ class ImageSaver:
         civitai_sampler_name = self.get_civitai_sampler_name(sampler_name.replace('_gpu', ''), scheduler)
 
         # Process additional_hashes input (a string) by normalizing, removing extra spaces/newlines, and splitting by comma
-        manual_list = additional_hashes.replace("\n", ",").split(",")
         manual_entries = {}
-
-        for entry in manual_list:
-            entry = entry.strip()
-            if not entry:
+        unnamed_count = 0
+        existing_hashes = {modelhash.lower()} | {t[2].lower() for t in loras.values()} | {t[2].lower() for t in embeddings.values()}  # Get set of parsed hashes
+        additional_hash_split = additional_hashes.replace("\n", ",").split(",") if additional_hashes else []
+        for entry in additional_hash_split:
+            match = (self.re_manual_hash_weights if download_civitai_data else self.re_manual_hash).search(entry)
+            if match is None:
+                print(f"ComfyUI-Image-Saver: Invalid additional hash string: '{entry}'")
                 continue
 
-            # Check if a name is provided using "Name:HASH" format
-            if ":" in entry:
-                name, hash_value = entry.split(":", 1)  # Only split at the first `:`
-                name, hash_value = name.strip(), hash_value.strip()
-            else:
-                name, hash_value = None, entry.strip()
+            groups = tuple(group for group in match.groups() if group)
 
-            if hash_value in manual_entries:
-                print(f"[ImageSaver] Skipping duplicate hash: {hash_value}")
+            # Read weight and remove from groups, if needed
+            weight = None
+            if download_civitai_data and len(groups) > 1:
+                try:
+                    weight = float(groups[-1])
+                    groups = groups[:-1]
+                except (ValueError, TypeError):
+                    pass
+
+            # Read hash, optionally preceded by name
+            name, hash = groups if len(groups) > 1 else (None, groups[0])
+
+            if len(hash) > self.MAX_HASH_LENGTH:
+                print(f"ComfyUI-Image-Saver: Skipping hash. Length exceeds maximum of {self.MAX_HASH_LENGTH} characters: {hash}")
+                continue
+
+            if any(hash.lower() == existing_hash.lower() for _, _, existing_hash in manual_entries.values()):
+                print(f"ComfyUI-Image-Saver: Skipping duplicate hash: {hash}")
                 continue  # Skip duplicates
 
-            manual_entries[hash_value] = name  # Store name-hash mapping
-
-        # Remove hashes already present in the computed LoRAs
-        existing_lora_hashes = set(loras.values())  # Get set of LoRA hashes
-        filtered_entries = {}
-        for hash_value, name in manual_entries.items():
-            if hash_value in existing_lora_hashes:
-                print(f"[ImageSaver] Skipping manual hash already present in LoRAs: {hash_value}")
+            if hash.lower() in existing_hashes:
+                print(f"ComfyUI-Image-Saver: Skipping manual hash already present in resources: {hash}")
                 continue
-            filtered_entries[hash_value] = name
 
-        # Limit to 30 manual hashes
-        limited_entries = dict(list(filtered_entries.items())[:30])
+            if name is None:
+                unnamed_count += 1
+                name = f"manual{unnamed_count}"
+            elif name in manual_entries:
+                print(f"ComfyUI-Image-Saver: Duplicate manual hash name '{name}' is being overwritten.")
 
-        # Store named hashes using the given name, otherwise use "manualX"
-        additional_hashes_dict = {}
-        for i, (hash_value, name) in enumerate(limited_entries.items(), start=1):
-            key_name = name if name else f"manual{i}"  # Use the given name, otherwise default to manualX
-            additional_hashes_dict[key_name] = hash_value
+            manual_entries[name] = (None, weight, hash)
 
-        # Convert all hashes to JSON format
-        hashes = json.dumps(embeddings | loras | additional_hashes_dict | {"model": modelhash})
+            if len(manual_entries) > 29:
+                print("ComfyUI-Image-Saver: Reached maximum limit of 30 manual hashes. Skipping the rest.")
+                break
+
+        # Download or load cache of Civitai data, save specially-formatted data to metadata
+        civitai_resources = []
+        hashes = {}
+        add_model_hash = None
+        if download_civitai_data:
+            for name, (filepath, weight, hash) in ({ modelname: ( ckpt_path, None, modelhash ) } | loras | embeddings | manual_entries).items():
+                civitai_info = self.get_civitai_info(filepath, hash)
+                if civitai_info is not None:
+                    resource_data = {}
+
+                    # Optional data - modelName, versionName
+                    resource_data["modelName"] = civitai_info["model"]["name"]
+                    resource_data["versionName"] = civitai_info["name"]
+                    
+                    # Weight/strength (for LoRA or embedding)
+                    if weight is not None:
+                        resource_data["weight"] = weight
+                    
+                    # Required data - AIR or modelVersionId (unique resource identifier)
+                    # https://github.com/civitai/civitai/wiki/AIR-%E2%80%90-Uniform-Resource-Names-for-AI
+                    if "air" in civitai_info:
+                        resource_data["air"] = civitai_info["air"]
+                    else:
+                        # Fallback if AIR is not found
+                        resource_data["modelVersionId"] = civitai_info["id"]
+                    civitai_resources.append(resource_data)
+                else:
+                    # Fallback in case the data wasn't loaded to add to the "Hashes" section
+                    if name == modelname:
+                        add_model_hash = hash.upper()
+                    else:
+                        hashes[name] = hash.upper()
+        else:
+            # Convert all hashes to JSON format
+            hashes = {key: value[2] for key, value in embeddings.items()} | {key: value[2] for key, value in loras.items()} | {key: value[2] for key, value in manual_entries.items()} | {"model": modelhash}
+            add_model_hash = modelhash
         basemodelname = parse_checkpoint_name_without_extension(modelname)
+
+        if easy_remix:
+            def clean_prompt(prompt: str) -> str:
+                # Strip loras
+                prompt = re.sub(metadata_extractor.LORA, "", prompt)
+                # Shorten 'embedding:path/to/my_embedding' -> 'my_embedding'
+                # Note: Possible inaccurate embedding name if the filename has been renamed from the default
+                prompt = re.sub(metadata_extractor.EMBEDDING, lambda match: Path(match.group(1)).stem, prompt)
+                # Remove prompt control edits. e.g., 'STYLE(A1111, mean)', 'SHIFT(1)`, etc.`
+                prompt = re.sub(r'\b[A-Z]+\([^)]*\)', "", prompt)
+                return prompt
+
+            positive = clean_prompt(positive)
+            negative = clean_prompt(negative)
 
         positive_a111_params = positive.strip()
         negative_a111_params = f"\nNegative prompt: {negative.strip()}"
-        a111_params = f"{positive_a111_params}{negative_a111_params}\nSteps: {steps}, Sampler: {civitai_sampler_name}, CFG scale: {cfg}, Seed: {seed_value}, Size: {width}x{height}{f', Clip skip: {abs(clip_skip)}' if clip_skip != 0 else ''}, Model hash: {modelhash}, Model: {basemodelname}, Hashes: {hashes}, Version: ComfyUI"
+        a111_params = (f"{positive_a111_params}{negative_a111_params}\nSteps: {steps}, Sampler: {civitai_sampler_name}, CFG scale: {cfg}, Seed: {seed_value}"
+            f", Size: {width}x{height}{f', Clip skip: {abs(clip_skip)}' if clip_skip != 0 else ''}{f', Model hash: {add_model_hash}' if add_model_hash else ''}"
+            f", Model: {basemodelname}{f', Hashes: {json.dumps(hashes, separators=(',', ':'))}' if hashes else ''}, Version: ComfyUI")
+
+        # Add Civitai resource listing
+        if download_civitai_data and civitai_resources:
+            a111_params += f", Civitai resources: {json.dumps(civitai_resources, separators=(',', ':'))}"
 
         output_path = os.path.join(self.output_dir, path)
 
@@ -304,3 +380,129 @@ class ImageSaver:
             next_suffix = 1
 
         return f"{filename_prefix}_{next_suffix:02d}"
+
+    @staticmethod
+    def get_manual_folder() -> Path:
+        return Path(folder_paths.models_dir) / "image-saver"
+
+    @staticmethod
+    def http_get_json(url: str) -> dict | None:
+        try:
+            response = requests.get(
+                url,
+                stream=True,
+                headers={},
+                proxies={ "http": None, "https": None },
+                timeout=300
+            )
+        except TimeoutError:
+            print(f"ComfyUI-Image-Saver: HTTP GET Request timed out for {url}")
+            return None
+
+        if not response.ok:
+            print(f"ComfyUI-Image-Saver: HTTP GET Request failed with error code: {response.status_code}: {response.reason}")
+            return None
+
+        try:
+            return response.json()
+        except ValueError as e:
+            print(f"ComfyUI-Image-Saver: HTTP Response JSON error: {e}")
+        return None
+
+    @staticmethod
+    def get_civitai_info(path: Path | str | None, model_hash: str) -> dict | None:
+        try:
+            if not model_hash:
+                print("ComfyUI-Image-Saver: Error: Missing hash.")
+                return None
+
+            # path is None for additional hashes added by the user - caches manually added hash data in the "image-saver" folder
+            if path is None:
+                manual_list = ImageSaver.get_manual_list()
+                manual_data = manual_list.get(model_hash.upper(), None)
+                if manual_data is None:
+                    content = ImageSaver.download_model_info(path, model_hash)
+                    if content is None:
+                        return None
+                    
+                    # dynamically receive filename from the website to save the metadata
+                    file = next((file for file in content["files"] if any(len(value) <= ImageSaver.MAX_HASH_LENGTH and value.upper() == model_hash.upper() for value in file["hashes"].values())), None)
+                    if file is None:
+                        print(f"ComfyUI-Image-Saver: ({model_hash}) No file hash matched in metadata (should be impossible)")
+                        return content
+                    filename = file["name"]
+
+                    # Cache data in a local file, removing the need for repeat http requests
+                    for hash_value in file["hashes"].values():
+                        if len(hash_value) <= ImageSaver.MAX_HASH_LENGTH:
+                            manual_list = ImageSaver.append_manual_list(hash_value.upper(), { "filename": filename, "type": content["model"]["type"] })
+
+                    ImageSaver.save_civitai_info_file(content, ImageSaver.get_manual_folder() / filename)
+                    return content
+                else:
+                    path = ImageSaver.get_manual_folder() / manual_data["filename"]
+
+            info_path = Path(path).with_suffix(".civitai.info").absolute()
+            with open(info_path, 'r') as file:
+                return json.load(file)
+        except FileNotFoundError:
+            return ImageSaver.download_model_info(path, model_hash)
+        except Exception as e:
+            print(f"ComfyUI-Image-Saver: Civitai info error: {e}")
+        return None
+
+    @staticmethod
+    def get_manual_list() -> dict[str, dict]:
+        folder = ImageSaver.get_manual_folder()
+        folder.mkdir(parents=True, exist_ok=True)
+        try:
+            manual_path = (folder / "manual-hashes.json").absolute()
+            with open(manual_path, 'r') as file:
+                return json.load(file)
+        except FileNotFoundError:
+            return {}
+        except Exception as e:
+            print(f"ComfyUI-Image-Saver: Manual list get error: {e}")
+        return {}
+
+    @staticmethod
+    def append_manual_list(key: str, value: dict) -> dict[str, dict]:
+        manual_list = ImageSaver.get_manual_list() | { key: value }
+        try:
+            with open((ImageSaver.get_manual_folder() / "manual-hashes.json").absolute(), 'w') as file:
+                file.write(json.dumps(manual_list, indent=4))
+        except Exception as e:
+            print(f"ComfyUI-Image-Saver: Manual list append error: {e}")
+        return manual_list
+
+    @staticmethod
+    def download_model_info(path: Path | str | None, model_hash: str) -> dict | None:
+        print(f"ComfyUI-Image-Saver: Downloading model info. for '{model_hash if path is None else f"{Path(path).stem}:{model_hash}"}'.")
+
+        content = ImageSaver.http_get_json(f'https://civitai.com/api/v1/model-versions/by-hash/{model_hash.upper()}')
+        if content is None:
+            return None
+        model_id = content["modelId"]
+        parent_model = ImageSaver.http_get_json(f'https://civitai.com/api/v1/models/{model_id}')
+        if not parent_model:
+            parent_model = {}
+
+        content["creator"] = parent_model.get("creator", "{}")
+        model_metadata = content["model"]
+        for metadata in [ "description", "tags", "allowNoCredit", "allowCommercialUse", "allowDerivatives", "allowDifferentLicense" ]:
+            model_metadata[metadata] = parent_model.get(metadata, "")
+
+        if path is not None:
+            ImageSaver.save_civitai_info_file(content, path)
+        
+        return content
+
+    @staticmethod
+    def save_civitai_info_file(content: dict, path: Path | str) -> bool:
+        try:
+            with open(Path(path).with_suffix(".civitai.info").absolute(), 'w') as info_file:
+                info_file.write(json.dumps(content, indent=4))
+        except Exception as e:
+            print(f"ComfyUI-Image-Saver: Save Civitai info error '{path}': {e}")
+            return False
+        return True


### PR DESCRIPTION
* Added a new node called `Image Saver (Civitai Downloader)`.
* This comes with 2 new options: `download_civitai_data` and `easy_remix`.
* The node will automatically contact the Civitai API to query information to save to the metadata. (Needed to save weights.)
* Weight data is now saved to the metadata. #64
* It downloads and caches the data so download only happens once.
* `download_civitai_data`: Selectively enable or disable the added features. Disabling will make this work like a regular `Image Saver` node.
* `easy_remix`: Strips data (LoRAs, simplify embedding text) from the prompt to make Remix on civitai.com more seamless.
* `additional_hash` now supports adding weights as well.
* Original nodes' functionality remains the same to prevent breaking existing workflows.