### PR TITLE
Cleaner output for sha256 progress bar.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -24,7 +24,8 @@ def get_sha256(file_path: str):
         file_size = os.fstat(f.fileno()).st_size
         block_size = 1048576 # 1 MB
 
-        with tqdm(None, f"Calculating sha256 for '{Path(file_path).stem}'", file_size, unit="B", unit_scale=True, unit_divisor=1024) as progress_bar:
+        print(f"ComfyUI-Image-Saver: Calculating sha256 for '{Path(file_path).stem}'")
+        with tqdm(None, None, file_size, unit="B", unit_scale=True, unit_divisor=1024) as progress_bar:
             for byte_block in iter(lambda: f.read(block_size), b""):
                 progress_bar.update(len(byte_block))
                 sha256_hash.update(byte_block)


### PR DESCRIPTION
Some cleaner output for the sha256 progress bar.
It will show the progress bar on the next line, making it more visible.