### PR TITLE
Add hashes as node output for chaining/accumulating.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -141,7 +141,8 @@ class ImageSaver:
             },
         }
 
-    RETURN_TYPES = ()
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("hashes",)
     FUNCTION = "save_files"
 
     OUTPUT_NODE = True
@@ -330,7 +331,11 @@ class ImageSaver:
         filenames = self.save_images(images, output_path, filename, a111_params, extension, quality_jpeg_or_webp, lossless_webp, optimize_png, prompt, extra_pnginfo, save_workflow_as_json, embed_workflow_in_png)
 
         subfolder = os.path.normpath(path)
-        return {"ui": {"images": map(lambda filename: {"filename": filename, "subfolder": subfolder if subfolder != '.' else '', "type": 'output'}, filenames)}}
+
+        return {
+            "result": (",".join(f"{Path(name.split(":")[-1]).stem + ":" if name else ""}{hash}{":" + str(weight) if weight is not None and download_civitai_data else ""}" for name, (_, weight, hash) in ({ modelname: ( ckpt_path, None, modelhash ) } | loras | embeddings | manual_entries).items()),),
+            "ui": {"images": map(lambda filename: {"filename": filename, "subfolder": subfolder if subfolder != '.' else '', "type": 'output'}, filenames)},
+        }
 
     def save_images(self, images, output_path, filename_prefix, a111_params, extension, quality_jpeg_or_webp, lossless_webp, optimize_png, prompt, extra_pnginfo, save_workflow_as_json, embed_workflow_in_png) -> list[str]:
         paths = list()

--- a/nodes.py
+++ b/nodes.py
@@ -143,6 +143,7 @@ class ImageSaver:
 
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("hashes",)
+    OUTPUT_TOOLTIPS = ("Comma-separated list of the hashes to chain with other Image Saver additional_hashes",)
     FUNCTION = "save_files"
 
     OUTPUT_NODE = True


### PR DESCRIPTION
Added a `hashes` link output to the Image Saver node containing a comma-separated list of the hashes from the generation to chain with other Image Saver `additional_hashes`.

This can be used to combine the resources from different nodes, if you were, for example, outputting a final image that combines resources from multiple image generations. (Blending or combining the images together in some way.)

This is more convenient than having to manually type all the additional hashes.