### PR TITLE
Add multi-modelname support and recursive model search fallback in ImageSaver node

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -362,8 +362,9 @@ class ImageSaver:
             hashes |= {key: value[2] for key, value in embeddings.items()}
             hashes |= {key: value[2] for key, value in loras.items()}
             hashes |= {key: value[2] for key, value in manual_entries.items()}
-            # Only pick a model hash if we actually have a modelname
-            add_model_hash = modelhashes.get(modelnames[0], "") if modelnames else ""
+            # For compatibility, if only one model, set "model" key
+            if modelnames and len(modelnames) == 1:
+                hashes["model"] = modelhashes.get(modelnames[0], "")
 
         if easy_remix:
             def clean_prompt(prompt: str) -> str:

--- a/nodes.py
+++ b/nodes.py
@@ -421,10 +421,16 @@ class ImageSaver:
             for mn in modelnames
         }
         combined = initial_map | loras | embeddings | manual_entries
+
         result_hashes = ",".join(
-            f"{Path(name.split(':')[-1]).stem + ':' if name else ''}{hash}{':' + str(weight) if weight is not None and download_civitai_data else ''}"
+            (
+                f"{Path(name).stem if name else ''}"
+                f"{':' if name else ''}{hash}"
+                f"{':' + str(weight) if weight is not None and download_civitai_data else ''}"
+            )
             for name, (_, weight, hash) in combined.items()
         )
+
         return {
             "result": (result_hashes,),
             "ui": {"images": map(lambda filename: {"filename": filename, "subfolder": subfolder if subfolder != '.' else '', "type": 'output'}, filenames)},


### PR DESCRIPTION
Closes #79 

### What
- Extended ImageSaver node to accept multiple model names (comma-separated).
- Improved model name resolution:
  - If model files are not found directly, now recursively searches all `models/checkpoints` subfolders.
  - Automatically appends `.safetensors` if missing.
- Cleaned model name handling to avoid directory errors.

I also need a real dev to check the code because it looks... ugly with a lot of ifs and elses... 😅 I blame chatgpt.

### Why
- Previously, the node accepted only one model name.
- Also, with multi-model implementation models in subfolders were not found unless users manually provided full relative paths.
- This update improves usability, supports multiple models, and avoids user error.

### How to test
- Input multiple model names separated by commas in the "modelname" field.
- Mix simple filenames and full relative paths.
- Confirm that all model hashes are correctly computed and embedded into the output metadata.

![image](https://github.com/user-attachments/assets/3228c421-62f9-43b5-a76f-fd67476b3c00)



