### PR TITLE
Proposal for unified input node for seed, steps, cfg, sampler, and scheduler, and empty latent image node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 from .nodes import ImageSaver
-from .nodes_literals import SeedGenerator, StringLiteral, SizeLiteral, IntLiteral, FloatLiteral, CfgLiteral
+from .nodes_literals import SeedGenerator, StringLiteral, SizeLiteral, IntLiteral, FloatLiteral, CfgLiteral, SizeLatent
 from .nodes_loaders import CheckpointLoaderWithName, UNETLoaderWithName
-from .nodes_selectors import SamplerSelector, SchedulerSelector, SchedulerSelectorComfy, SchedulerToString, SamplerToString, SchedulerComfyToString
+from .nodes_selectors import SamplerSelector, SchedulerSelector, SchedulerSelectorComfy, SchedulerToString, SamplerToString, SchedulerComfyToString, KSamplerParameters
 from .civitai_nodes import CivitaiHashFetcher
 
 NODE_CLASS_MAPPINGS = {
@@ -11,6 +11,7 @@ NODE_CLASS_MAPPINGS = {
     "Sampler Selector (Image Saver)": SamplerSelector,
     "Scheduler Selector (Image Saver)": SchedulerSelector,
     "Scheduler Selector (Comfy) (Image Saver)": SchedulerSelectorComfy,
+    "KSampler Parameters (Image Saver)": KSamplerParameters,
     "Seed Generator (Image Saver)": SeedGenerator,
     "String Literal (Image Saver)": StringLiteral,
     "Width/Height Literal (Image Saver)": SizeLiteral,
@@ -20,6 +21,7 @@ NODE_CLASS_MAPPINGS = {
     "SchedulerToString (Image Saver)": SchedulerToString,
     "SchedulerComfyToString (Image Saver)": SchedulerComfyToString,
     "SamplerToString (Image Saver)": SamplerToString,
+    "Empty Latent Image (Image Saver)": SizeLatent,
     "Civitai Hash Fetcher (Image Saver)": CivitaiHashFetcher,
 }
 

--- a/nodes_selectors.py
+++ b/nodes_selectors.py
@@ -119,3 +119,35 @@ class SamplerToString:
 
     def get_name(self, sampler):
         return (sampler,)
+
+class KSamplerParameters:
+    RETURN_TYPES = ("INT", "INT", "FLOAT", comfy.samplers.KSampler.SAMPLERS, "STRING", comfy.samplers.KSampler.SCHEDULERS, "STRING")
+    RETURN_NAMES = ("seed", "steps", "cfg", "sampler", "sampler_name", "scheduler", "scheduler_name")
+    OUTPUT_TOOLTIPS = (
+        "seed (INT)",
+        "steps (INT)",
+        "cfg (FLOAT)",
+        "sampler (SAMPLERS)",
+        "sampler name (STRING)",
+        "scheduler (SCHEDULERS)",
+        "scheduler name (STRING)"
+    )
+    FUNCTION = "get_values"
+
+    CATEGORY = "ImageSaver/utils"
+    DESCRIPTION = "Combined node for seed, steps, cfg, sampler, and scheduler."
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "tooltip": "seed as integer number"}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 1000000, "tooltip": "number of sampling steps"}),
+                "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0, "tooltip": "CFG as a floating point number"}),
+                "sampler": (comfy.samplers.KSampler.SAMPLERS, {"tooltip": "Sampler type"}),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS, {"tooltip": "Scheduler type"}),
+            }
+        }
+
+    def get_values(self, seed, steps, cfg, sampler, scheduler):
+        return (seed, steps, cfg, sampler, sampler, scheduler, scheduler)


### PR DESCRIPTION
This PR introduces a node combines the following common inputs into a single interface:

- seed (INT)
- steps (INT)
- cfg (FLOAT)
- sampler (SAMPLERS + STRING name)
- scheduler (SCHEDULERS + STRING name)

Added a vanilla Empty Latent Image node with width/height output values.

![image](https://github.com/user-attachments/assets/b636c275-d8de-4560-bade-32f22ca81143)

Opening this as a proposal to get feedback.