### PR TITLE
Fixed timeout exception to prevent network timeout crashes

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -100,7 +100,7 @@ def __list_diffusion_models() -> list[str]:
 def http_get_json(url: str) ->  dict[str, Any] | None:
     try:
         response = requests.get(url, stream=True, headers={}, timeout=300)
-    except TimeoutError:
+    except requests.exceptions.Timeout:
         print(f"ComfyUI-Image-Saver: HTTP GET Request timed out for {url}")
         return None
     except requests.exceptions.ConnectionError as e:

--- a/utils.py
+++ b/utils.py
@@ -99,7 +99,7 @@ def __list_diffusion_models() -> list[str]:
 
 def http_get_json(url: str) ->  dict[str, Any] | None:
     try:
-        response = requests.get(url, stream=True, headers={}, timeout=300)
+        response = requests.get(url, timeout=300)
     except requests.exceptions.Timeout:
         print(f"ComfyUI-Image-Saver: HTTP GET Request timed out for {url}")
         return None


### PR DESCRIPTION
I noticed that `except TimeoutError:` doesn't get triggered for `response.get()` function, so replaced it with `except requests.exceptions.Timeout:`.