### PR TITLE
Fix `endswith` filename collision error.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -55,7 +55,7 @@ def get_sha256(file_path: str) -> str:
 Based on a embedding name, eg: EasyNegative, finds the path as known in comfy, including extension
 """
 def full_embedding_path_for(embedding: str) -> Optional[str]:
-    matching_embedding = next((x for x in folder_paths.get_filename_list("embeddings") if x.startswith(embedding)), None)
+    matching_embedding = next((x for x in folder_paths.get_filename_list("embeddings") if Path(x).with_suffix('') == Path(embedding)), None)
     if matching_embedding == None:
         return None
     return folder_paths.get_full_path("embeddings", matching_embedding)
@@ -70,7 +70,7 @@ def full_lora_path_for(lora: str) -> Optional[str]:
         lora += ".safetensors"
 
     # Find the matching lora path
-    matching_lora = next((x for x in folder_paths.get_filename_list("loras") if x.endswith(lora)), None)
+    matching_lora = next((x for x in folder_paths.get_filename_list("loras") if Path(x).name == lora), None)
     if matching_lora is None:
         print(f'ComfyUI-Image-Saver: could not find full path to lora "{lora}"')
         return None
@@ -86,11 +86,11 @@ def full_checkpoint_path_for(model_name: str) -> str:
     if extension.lower() not in supported_extensions:
         model_name += ".safetensors"
 
-    matching_checkpoint = next((x for x in folder_paths.get_filename_list("checkpoints") if x.endswith(model_name)), None)
+    matching_checkpoint = next((x for x in folder_paths.get_filename_list("checkpoints") if Path(x) == Path(model_name)), None)
     if matching_checkpoint:
         return folder_paths.get_full_path("checkpoints", matching_checkpoint)
 
-    matching_model = next((x for x in folder_paths.get_filename_list("diffusion_models") if x.endswith(model_name)), None)
+    matching_model = next((x for x in folder_paths.get_filename_list("diffusion_models") if Path(x) == Path(model_name)), None)
     if matching_model:
         return folder_paths.get_full_path("diffusion_models", matching_model)
 


### PR DESCRIPTION
Fixing an error with the filepath matching for loras, which only checked if the end of the filename matched. This caused a possible collision with a different filename that ends with the desired filename. E.g., trying to match 'my_lora' but instead matching 'abc_my_lora' since it was only checking `endswith`.

The code has been updated to check to the full filename matches instead of just ending with.

I've also updated the embedding name match to prevent possible collisions and added a more robust check to the checkpoint name match. The checkpoint name match was unlikely to be an issue with the previous code, since it is guaranteed to be the full relative path on both sides, but I added a check that will work if there is a backslash/forward-slash mismatch.