### PR TITLE
Fix Civitai Hash Fetcher search issues

### DIFF
--- a/civitai_nodes.py
+++ b/civitai_nodes.py
@@ -48,7 +48,7 @@ class CivitaiHashFetcher:
 
         try:
             # Fetch models by username and model name
-            response = requests.get(base_url, params=params)
+            response = requests.get(base_url, params=params, timeout=10)
             if response.status_code != 200:
                 return (f"Error: API request failed with status {response.status_code}",)
 
@@ -57,13 +57,13 @@ class CivitaiHashFetcher:
 
             # If no results with query, try without query (fallback for API search issues)
             if not items and params.get("query"):
-                print(f"ComfyUI-Image-Saver: No results with query, trying without query parameter...")
+                print("ComfyUI-Image-Saver: No results with query, trying without query parameter...")
                 params_no_query = {
                     "username": username,
                     "limit": 100,
                     "nsfw": "true"
                 }
-                response = requests.get(base_url, params=params_no_query)
+                response = requests.get(base_url, params=params_no_query, timeout=10)
                 if response.status_code == 200:
                     data = response.json()
                     items = data.get("items", [])
@@ -112,7 +112,7 @@ class CivitaiHashFetcher:
 
             # Fetch detailed version info
             version_url = f"https://civitai.com/api/v1/model-versions/{version_id}"
-            version_response = requests.get(version_url)
+            version_response = requests.get(version_url, timeout=10)
             if version_response.status_code != 200:
                 return (f"Error: Version API request failed with status {version_response.status_code}",)
 


### PR DESCRIPTION
# Fix Civitai Hash Fetcher search issues

## Summary

This PR fixes multiple issues with the Civitai Hash Fetcher node that prevented it from finding models.

## Changes

- Increased API result limit from 1 to 20 to work around Civitai's API ranking issues
- Added nsfw parameter to include NSFW models in search results
- Added fallback to fetch all user models when search query returns no results
- Implemented smart client-side matching for partial and exact name matches

## Issues Fixed

1. **Civitai API ranking**: With limit=1, some models weren't returned as the top result even with accurate search terms
2. **NSFW filtering**: NSFW models were filtered out by default
3. **Search query failures**: The API's query parameter sometimes fails to find models that exist (likely due to special characters or search indexing issues)

## Testing

Tested with:

- ✅ Partial model names (e.g., "Proper Flux Control-Net")
- ✅ Complete model names
- ✅ NSFW models
- ✅ Models with special characters in names

The node now successfully finds models that previously returned "No models found" errors.