### PR TITLE
Change `steps` minimum to zero so Civitai skips it.

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -332,7 +332,7 @@ class ImageSaver:
                 "extension":             (['png', 'jpeg', 'jpg', 'webp'], {                                        "tooltip": "file extension/type to save image as"}),
             },
             "optional": {
-                "steps":                 ("INT",     {"default": 20, "min": 1, "max": 10000,                       "tooltip": "number of steps"}),
+                "steps":                 ("INT",     {"default": 20, "min": 0, "max": 10000,                       "tooltip": "number of steps"}),
                 "cfg":                   ("FLOAT",   {"default": 7.0, "min": 0.0, "max": 100.0,                    "tooltip": "CFG value"}),
                 "modelname":             ("STRING",  {"default": '', "multiline": False,                           "tooltip": "model name (can be multiple, separated by commas)"}),
                 "sampler_name":          ("STRING",  {"default": '', "multiline": False,                           "tooltip": "sampler name (as string)"}),


### PR DESCRIPTION
Add ability to set `steps` to zero. Since this is invalid, it won't appear on Civitai.

All other inputs have values that will remove them from the Civitai metadata except for `steps`.

This is useful if you want to add other metadata but not `steps`.