### PR TITLE
feat: support zero-padded counter format

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can use following placeholders:
 - `%basemodelname` *– name of model (without file extension)*
 - `%seed`
 - `%counter`
+- `%counter<padding>` *– zero-padded counter (e.g. `%counter<03>` with counter 1 becomes `001`)*
 - `%sampler_name`
 - `%scheduler`
 - `%steps`

--- a/nodes.py
+++ b/nodes.py
@@ -60,6 +60,23 @@ def apply_custom_time_format(filename: str) -> str:
 
     return re.sub(pattern, replace_format, filename)
 
+def apply_custom_counter_format(filename: str, counter: int) -> str:
+    """
+    Replace %counter<padding> patterns with formatted counter.
+    Example: %counter<03> with counter=1 becomes 001
+    """
+    pattern = r'%counter<([0-9]+)>'
+    def replace_format(match):
+        padding_str = match.group(1)
+        try:
+            # Create format string like "{:03d}"
+            fmt = "{:0" + padding_str + "d}"
+            return fmt.format(counter)
+        except:
+            return match.group(0)
+
+    return re.sub(pattern, replace_format, filename)
+
 def save_json(image_info: dict[str, Any] | None, filename: str) -> None:
     try:
         workflow = (image_info or {}).get('workflow')
@@ -72,8 +89,9 @@ def save_json(image_info: dict[str, Any] | None, filename: str) -> None:
         print(f'Failed to save workflow as json due to: {e}, proceeding with the remainder of saving execution')
 
 def make_pathname(filename: str, width: int, height: int, seed: int, modelname: str, counter: int, time_format: str, sampler_name: str, steps: int, cfg: float, scheduler_name: str, denoise: float, clip_skip: int, custom: str) -> str:
-    # Process custom time_format patterns first
+    # Process custom format patterns first
     filename = apply_custom_time_format(filename)
+    filename = apply_custom_counter_format(filename, counter)
     filename = filename.replace("%date", get_timestamp("%Y-%m-%d"))
     filename = filename.replace("%time", get_timestamp(time_format))
     filename = filename.replace("%model", parse_checkpoint_name(modelname))
@@ -255,7 +273,7 @@ class ImageSaverSimple:
         return {
             "required": {
                 "images":                ("IMAGE",    {                                                             "tooltip": "image(s) to save"}),
-                "filename":              ("STRING",   {"default": '%time_%basemodelname_%seed', "multiline": False, "tooltip": "filename (available variables: %date, %time, %time_format<format>, %model, %width, %height, %seed, %counter, %sampler_name, %steps, %cfg, %scheduler_name, %basemodelname, %denoise, %clip_skip)"}),
+                "filename":              ("STRING",   {"default": '%time_%basemodelname_%seed', "multiline": False, "tooltip": "filename (available variables: %date, %time, %time_format<format>, %model, %width, %height, %seed, %counter, %counter<padding>, %sampler_name, %steps, %cfg, %scheduler_name, %basemodelname, %denoise, %clip_skip)"}),
                 "path":                  ("STRING",   {"default": '', "multiline": False,                           "tooltip": "path to save the images (under Comfy's save directory)"}),
                 "extension":             (['png', 'jpeg', 'jpg', 'webp'], {                                         "tooltip": "file extension/type to save image as"}),
                 "lossless_webp":         ("BOOLEAN",  {"default": True,                                             "tooltip": "if True, saved WEBP files will be lossless"}),
@@ -327,7 +345,7 @@ class ImageSaver:
         return {
             "required": {
                 "images":                ("IMAGE",   {                                                             "tooltip": "image(s) to save"}),
-                "filename":              ("STRING",  {"default": '%time_%basemodelname_%seed', "multiline": False, "tooltip": "filename (available variables: %date, %time, %time_format<format>, %model, %width, %height, %seed, %counter, %sampler_name, %steps, %cfg, %scheduler_name, %basemodelname, %denoise, %clip_skip)"}),
+                "filename":              ("STRING",  {"default": '%time_%basemodelname_%seed', "multiline": False, "tooltip": "filename (available variables: %date, %time, %time_format<format>, %model, %width, %height, %seed, %counter, %counter<padding>, %sampler_name, %steps, %cfg, %scheduler_name, %basemodelname, %denoise, %clip_skip)"}),
                 "path":                  ("STRING",  {"default": '', "multiline": False,                           "tooltip": "path to save the images (under Comfy's save directory)"}),
                 "extension":             (['png', 'jpeg', 'jpg', 'webp'], {                                        "tooltip": "file extension/type to save image as"}),
             },


### PR DESCRIPTION
  This PR introduces the ability to format the filename counter with zero-padding using the new %counter<padding> syntax. 

  For example, using %counter<03> when the counter is set to 1 will output 001. This allows for much cleaner and more easily
  sortable image sequences when batch generating. The original %counter syntax is preserved for backwards compatibility and
  outputs the raw unpadded integer.

  The feature works seamlessly alongside the existing filename placeholders and includes fallback handling so invalid formats
  safely render the raw placeholder string rather than crashing. 