### PR TITLE
Add Civitai-compatible video metadata saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add Civitai-compatible metadata saving for native ComfyUI VIDEO (including audio) and VideoHelperSuite outputs.
+
 # v1.24.0
 
 - Add rng artist/tag picker.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ You can find example workflows in the [`examples`](./examples) directory.
 You can also add LoRAs to the prompt in \<lora:name:weight\> format, which would be translated into hashes and stored together with the metadata. For this it is recommended to use `ImpactWildcardEncode` from the fantastic [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack). It will allow you to convert the LoRAs directly to proper conditioning without having to worry about avoiding/concatenating lora strings, which have no effect in standard conditioning nodes. Here is an example:
 ![workflow](https://github.com/user-attachments/assets/61440fac-f1d5-414b-ae69-dbdda9d6d442)
 
+## Video metadata
+
+The video nodes preserve the same positive/negative prompts, settings, model and LoRA hashes, and Civitai resource list used by the image saver. They also write the ComfyUI prompt/workflow when enabled.
+
+For native ComfyUI video workflows, use `Image Saver — Save Native Video (VIDEO + Audio)`. Connect the native `VIDEO` output from `Create Video` or another native video node to `video`, and connect `Image Saver Metadata` to `metadata`. This is the actual saver: it encodes the native frames plus optional audio, then adds metadata. Its filename prefix supports Image Saver placeholders such as `%time`, `%basemodelname`, and `%seed`.
+
+For VideoHelperSuite, keep `save_metadata` enabled on `Video Combine`, then connect its `VHS_FILENAMES` output to `Image Saver — Add Metadata to VHS Video` and connect `Image Saver Metadata` to `metadata`. This is not another video encoder: it post-processes files already written by VHS and creates a suffixed MP4/WebM copy by default, preserving the original and all existing video/audio streams.
+
+Both paths write an A1111-compatible `parameters` tag plus structured `prompt`, workflow/extra-info, `civitaiResources`, and `extraMetadata` tags. These are the tags the companion [Civitai Video Metadata Assistant](https://github.com/diodiogod/Civitai-Video-Metadata-Assistant) can read before upload while Civitai's native video-metadata support is still pending.
+
 This would have civitai autodetect all of the resources (assuming the model/lora/embedding hashes match):
 ![image](https://github.com/alexopus/ComfyUI-Image-Saver/assets/25933468/f0642389-4f34-4a64-89a6-5cf9c33d5ed1)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from .nodes import ImageSaver, ImageSaverSimple, ImageSaverMetadata
+from .nodes import ImageSaver, ImageSaverSimple, ImageSaverMetadata, ImageSaverVideoMetadata, ImageSaverSaveVideo
 from .nodes_pipe import MakeImageSaverPipe, EditImageSaverPipe, ReadImageSaverPipe, ImageSaverFromPipe, MakeImageSaverSimpleConfig, MakeImageSaverMetadataConfig
 from .nodes_literals import SeedGenerator, StringLiteral, SizeLiteral, IntLiteral, FloatLiteral, CfgLiteral, ConditioningConcatOptional, RandomShapeGenerator, EmptyLatent
 from .nodes_loaders import CheckpointLoaderWithName, UNETLoaderWithName
@@ -20,6 +20,8 @@ NODE_CLASS_MAPPINGS: dict[str, Any] = {
     "Edit Image Saver Pipe": EditImageSaverPipe,
     "Read Image Saver Pipe": ReadImageSaverPipe,
     "Image Saver (From Pipe)": ImageSaverFromPipe,
+    "Image Saver Video Metadata": ImageSaverVideoMetadata,
+    "Image Saver Save Video": ImageSaverSaveVideo,
     "Sampler Selector (Image Saver)": SamplerSelector,
     "Scheduler Selector (Image Saver)": SchedulerSelector,
     "Scheduler Selector (inspire) (Image Saver)": SchedulerSelectorInspire,
@@ -44,4 +46,9 @@ NODE_CLASS_MAPPINGS: dict[str, Any] = {
 
 WEB_DIRECTORY = "js"
 
-__all__ = ['NODE_CLASS_MAPPINGS', 'WEB_DIRECTORY']
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "Image Saver Save Video": "Image Saver — Save Native Video (VIDEO + Audio)",
+    "Image Saver Video Metadata": "Image Saver — Add Metadata to VHS Video",
+}
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS', 'WEB_DIRECTORY']

--- a/nodes.py
+++ b/nodes.py
@@ -14,7 +14,14 @@ import folder_paths
 from nodes import MAX_RESOLUTION
 
 from .saver.saver import save_image
-from .saver.video import build_video_metadata, embed_video_metadata, native_video_metadata, pack_vhs_filenames, unpack_vhs_filenames
+from .saver.video import (
+    build_video_metadata,
+    embed_video_metadata,
+    native_video_metadata,
+    pack_vhs_filenames,
+    select_vhs_video_file,
+    unpack_vhs_filenames,
+)
 from .utils import sanitize_filename, get_sha256, full_checkpoint_path_for
 from .utils_civitai import get_civitai_sampler_name, get_civitai_metadata, MAX_HASH_LENGTH
 from .prompt_metadata_extractor import PromptMetadataExtractor
@@ -383,6 +390,7 @@ class ImageSaverVideoMetadata:
         save_output, source_files = unpack_vhs_filenames(filenames)
         if not source_files:
             raise ValueError("Image Saver Video Metadata received no video files.")
+        source_file = select_vhs_video_file(source_files)
 
         tags = build_video_metadata(
             metadata,
@@ -394,12 +402,11 @@ class ImageSaverVideoMetadata:
 
         output_files = [
             embed_video_metadata(
-                source,
+                source_file,
                 tags,
                 suffix=filename_suffix,
                 overwrite=overwrite_existing,
             )
-            for source in source_files
         ]
 
         result: dict[str, Any] = {

--- a/nodes.py
+++ b/nodes.py
@@ -14,6 +14,7 @@ import folder_paths
 from nodes import MAX_RESOLUTION
 
 from .saver.saver import save_image
+from .saver.video import build_video_metadata, embed_video_metadata, native_video_metadata, pack_vhs_filenames, unpack_vhs_filenames
 from .utils import sanitize_filename, get_sha256, full_checkpoint_path_for
 from .utils_civitai import get_civitai_sampler_name, get_civitai_metadata, MAX_HASH_LENGTH
 from .prompt_metadata_extractor import PromptMetadataExtractor
@@ -338,6 +339,239 @@ class ImageSaverSimple:
             result["ui"] = {"images": [{"filename": filename, "subfolder": subfolder if subfolder != '.' else '', "type": 'output'} for filename in filenames]}
 
         return result
+
+
+class ImageSaverVideoMetadata:
+    """Add metadata to existing VideoHelperSuite file outputs."""
+
+    @classmethod
+    def INPUT_TYPES(cls) -> dict[str, Any]:
+        return {
+            "required": {
+                "filenames": ("VHS_FILENAMES", {"tooltip": "VideoHelperSuite only: connect the VHS_FILENAMES output from Video Combine. This is not the native VIDEO type."}),
+                "filename_suffix": ("STRING", {"default": "_civitai", "multiline": False, "tooltip": "Suffix for the metadata-enriched MP4/WebM copy"}),
+                "overwrite_existing": ("BOOLEAN", {"default": False, "tooltip": "Replace the original video instead of creating a suffixed copy"}),
+                "embed_workflow": ("BOOLEAN", {"default": True, "tooltip": "Embed ComfyUI prompt/workflow metadata in addition to Civitai parameters"}),
+            },
+            "optional": {
+                "metadata": ("METADATA", {"default": None, "tooltip": "Image Saver Metadata output containing prompt, hashes, and Civitai resources"}),
+            },
+            "hidden": {
+                "prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+            },
+        }
+
+    RETURN_TYPES = ("VHS_FILENAMES",)
+    RETURN_NAMES = ("Filenames",)
+    OUTPUT_TOOLTIPS = ("VideoHelperSuite filenames for the metadata-enriched MP4/WebM copies.",)
+    OUTPUT_NODE = True
+    FUNCTION = "save_video_metadata"
+    CATEGORY = "ImageSaver"
+    DESCRIPTION = "VideoHelperSuite postprocessor: add Civitai-compatible metadata to existing VHS MP4/WebM files. Use Image Saver Save Video for native ComfyUI VIDEO values."
+
+    def save_video_metadata(
+        self,
+        filenames: Any,
+        filename_suffix: str = "_civitai",
+        overwrite_existing: bool = False,
+        embed_workflow: bool = True,
+        metadata: Metadata | None = None,
+        prompt: dict[str, Any] | None = None,
+        extra_pnginfo: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        save_output, source_files = unpack_vhs_filenames(filenames)
+        if not source_files:
+            raise ValueError("Image Saver Video Metadata received no video files.")
+
+        tags = build_video_metadata(
+            metadata,
+            prompt if embed_workflow else None,
+            extra_pnginfo if embed_workflow else None,
+        )
+        if not tags:
+            raise ValueError("No metadata was available. Connect Image Saver Metadata or run the node in a ComfyUI workflow.")
+
+        output_files = [
+            embed_video_metadata(
+                source,
+                tags,
+                suffix=filename_suffix,
+                overwrite=overwrite_existing,
+            )
+            for source in source_files
+        ]
+
+        result: dict[str, Any] = {
+            "result": (pack_vhs_filenames(save_output, output_files),),
+        }
+
+        output_directory = Path(folder_paths.get_output_directory()).resolve()
+        previews = []
+        for output_file in output_files:
+            path = Path(output_file).resolve()
+            try:
+                subfolder = os.path.relpath(path.parent, output_directory)
+            except ValueError:
+                subfolder = ""
+            previews.append({
+                "filename": path.name,
+                "subfolder": "" if subfolder in {"", "."} else subfolder,
+                "type": "output" if save_output else "temp",
+                "format": f"video/{path.suffix.lstrip('.').lower()}",
+            })
+        # Match ComfyUI's native PreviewVideo payload so the frontend renders
+        # an inline video player on the node after execution.
+        result["ui"] = {"images": previews, "animated": (True,)}
+        return result
+
+
+class ImageSaverSaveVideo:
+    """Save native ComfyUI VIDEO values, including optional audio, with metadata."""
+
+    @classmethod
+    def INPUT_TYPES(cls) -> dict[str, Any]:
+        return {
+            "required": {
+                "video": ("VIDEO", {"tooltip": "Native ComfyUI VIDEO from Create Video or another native video node. It can contain image frames plus audio."}),
+                "filename_prefix": ("STRING", {"default": "video/%time_%basemodelname_%seed", "multiline": False, "tooltip": "Output prefix. Image Saver placeholders are supported: %date, %time, %model, %basemodelname, %width, %height, %seed, %counter, %sampler_name, %steps, %cfg, %scheduler, %denoise, %clip_skip."}),
+                "format": (["auto", "mp4"], {"default": "auto", "tooltip": "Container format. Native ComfyUI currently writes MP4."}),
+                "codec": (["auto", "h264"], {"default": "auto", "tooltip": "Video codec. Native component videos are encoded as H.264."}),
+                "crf": ("FLOAT", {"default": 23.0, "min": 0.0, "max": 51.0, "step": 1.0, "tooltip": "Quality for H.264 re-encoding when requested"}),
+                "embed_workflow": ("BOOLEAN", {"default": True, "tooltip": "Embed ComfyUI prompt/workflow metadata in addition to Civitai parameters"}),
+            },
+            "optional": {
+                "metadata": ("METADATA", {"default": None, "tooltip": "Image Saver Metadata output containing prompt, hashes, and Civitai resources"}),
+                "time_format": ("STRING", {"default": "%Y-%m-%d-%H%M%S", "multiline": False, "tooltip": "strftime format used by the %time and %date filename placeholders"}),
+            },
+            "hidden": {
+                "prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+            },
+        }
+
+    RETURN_TYPES = ("VIDEO",)
+    RETURN_NAMES = ("video",)
+    OUTPUT_TOOLTIPS = ("The native VIDEO value, forwarded for downstream nodes after saving.",)
+    OUTPUT_NODE = True
+    FUNCTION = "save_video"
+    CATEGORY = "ImageSaver"
+    DESCRIPTION = "Native ComfyUI VIDEO saver: preserves image frames and optional audio while writing Civitai-compatible prompt, hashes, resources, and workflow metadata."
+
+    def save_video(
+        self,
+        video: Any,
+        filename_prefix: str = "video/ComfyUI",
+        format: str = "auto",
+        codec: str = "auto",
+        crf: float = 23.0,
+        embed_workflow: bool = True,
+        metadata: Metadata | None = None,
+        time_format: str = "%Y-%m-%d-%H%M%S",
+        prompt: dict[str, Any] | None = None,
+        extra_pnginfo: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        try:
+            from comfy_api.latest import Types
+        except ImportError as error:
+            raise RuntimeError("Image Saver Save Video requires a ComfyUI version with the native VIDEO type.") from error
+
+        if video is None or not hasattr(video, "save_to"):
+            raise TypeError("Image Saver Save Video expected a native ComfyUI VIDEO value.")
+
+        tags = build_video_metadata(
+            metadata,
+            prompt if embed_workflow else None,
+            extra_pnginfo if embed_workflow else None,
+        )
+        if not tags:
+            raise ValueError("No metadata was available. Connect Image Saver Metadata or run the node in a ComfyUI workflow.")
+
+        width, height = video.get_dimensions()
+        modelname = getattr(metadata, "modelname", "") if metadata is not None else ""
+        seed = getattr(metadata, "seed", 0) if metadata is not None else 0
+        steps = getattr(metadata, "steps", 20) if metadata is not None else 20
+        cfg = getattr(metadata, "cfg", 7.0) if metadata is not None else 7.0
+        sampler_name = getattr(metadata, "sampler_name", "") if metadata is not None else ""
+        scheduler_name = getattr(metadata, "scheduler_name", "") if metadata is not None else ""
+        denoise = getattr(metadata, "denoise", 1.0) if metadata is not None else 1.0
+        clip_skip = getattr(metadata, "clip_skip", 0) if metadata is not None else 0
+        filename_prefix = re.sub(r"%scheduler(?!_name)", "%scheduler_name", filename_prefix)
+        prefix_without_counter = filename_prefix.replace("%counter", "")
+        probe_prefix = make_pathname(
+            prefix_without_counter,
+            width,
+            height,
+            seed,
+            modelname,
+            0,
+            time_format,
+            sampler_name,
+            steps,
+            cfg,
+            scheduler_name,
+            denoise,
+            clip_skip,
+            "",
+        )
+        _, _, probe_counter, _, _ = folder_paths.get_save_image_path(
+            probe_prefix,
+            folder_paths.get_output_directory(),
+            width,
+            height,
+        )
+        resolved_prefix = make_pathname(
+            filename_prefix,
+            width,
+            height,
+            seed,
+            modelname,
+            probe_counter,
+            time_format,
+            sampler_name,
+            steps,
+            cfg,
+            scheduler_name,
+            denoise,
+            clip_skip,
+            "",
+        )
+        full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
+            resolved_prefix,
+            folder_paths.get_output_directory(),
+            width,
+            height,
+        )
+        extension = Types.VideoContainer.get_extension(format)
+        output_file = f"{filename}_{counter:05}_.{extension}"
+        output_path = os.path.join(full_output_folder, output_file)
+        video.save_to(
+            output_path,
+            format=Types.VideoContainer(format),
+            codec=Types.VideoCodec(codec),
+            metadata=native_video_metadata(tags),
+            crf=crf,
+        )
+        # Native VIDEO correctly combines image frames and optional audio, but
+        # its component encoder JSON-serializes string values. Remux the
+        # finished file losslessly so the A1111 ``parameters`` tag and the
+        # structured tags have the exact text expected by Civitai readers.
+        embed_video_metadata(output_path, tags, overwrite=True)
+
+        return {
+            "result": (video,),
+            "ui": {
+                # This is the legacy-node equivalent of
+                # ui.PreviewVideo([ui.SavedResult(...)]) used by ComfyUI's
+                # native Save Video node.
+                "images": [{
+                    "filename": output_file,
+                    "subfolder": subfolder,
+                    "type": "output",
+                }],
+                "animated": (True,),
+            },
+        }
 
 class ImageSaver:
     @classmethod

--- a/saver/test_video.py
+++ b/saver/test_video.py
@@ -1,0 +1,108 @@
+import json
+import shutil
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from .video import (
+    build_video_metadata,
+    embed_video_metadata,
+    escape_ffmetadata,
+    native_video_metadata,
+    unpack_vhs_filenames,
+)
+
+
+def test_build_video_metadata_preserves_civitai_contract():
+    metadata = SimpleNamespace(
+        a111_params=(
+            "positive\nNegative prompt: negative\n"
+            "Steps: 12, Hashes: {\"model\":\"ABCDEF1234\"}, "
+            "Civitai resources: [{\"modelVersionId\":123,\"type\":\"checkpoint\"}]"
+        )
+    )
+    tags = build_video_metadata(
+        metadata,
+        {"1": {"class_type": "KSampler"}},
+        {"workflow": {"nodes": []}},
+    )
+
+    assert tags["parameters"] == metadata.a111_params
+    assert json.loads(tags["prompt"])["1"]["class_type"] == "KSampler"
+    assert json.loads(tags["workflow"]) == {"nodes": []}
+    assert json.loads(tags["civitaiResources"])[0]["modelVersionId"] == 123
+    assert json.loads(tags["extraMetadata"])["civitaiResources"][0]["type"] == "checkpoint"
+
+
+def test_escape_ffmetadata():
+    assert escape_ffmetadata(r"a=b;c#d\e\nf") == r"a\=b\;c\#d\\e\\nf"
+
+
+def test_unpack_vhs_filenames():
+    assert unpack_vhs_filenames((False, ["one.mp4", "two.webm"])) == (False, ["one.mp4", "two.webm"])
+    assert unpack_vhs_filenames(["one.mp4"]) == (True, ["one.mp4"])
+
+
+def test_native_video_metadata_avoids_double_serializing_parameters():
+    tags = {
+        "parameters": "positive\nNegative prompt: negative",
+        "prompt": '{"1":{"class_type":"KSampler"}}',
+        "civitaiResources": '[{"modelVersionId":123}]',
+    }
+
+    native = native_video_metadata(tags)
+
+    assert "parameters" not in native
+    assert native["prompt"] == {"1": {"class_type": "KSampler"}}
+    assert native["civitaiResources"] == [{"modelVersionId": 123}]
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None, reason="FFmpeg and FFprobe are required")
+def test_embed_video_metadata_mp4(tmp_path):
+    source = tmp_path / "source.mp4"
+    subprocess.run(
+        [
+            shutil.which("ffmpeg"),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=black:s=16x16:d=0.1",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            str(source),
+        ],
+        check=True,
+    )
+
+    output = embed_video_metadata(
+        source,
+        {
+            "parameters": "positive\nNegative prompt: negative",
+            "civitaiResources": '[{"modelVersionId":123}]',
+        },
+    )
+    probe = subprocess.run(
+        [
+            shutil.which("ffprobe"),
+            "-v",
+            "error",
+            "-show_entries",
+            "format_tags=parameters,civitaiResources",
+            "-of",
+            "json",
+            output,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tags = json.loads(probe.stdout)["format"]["tags"]
+    assert tags["parameters"] == "positive\nNegative prompt: negative"
+    assert json.loads(tags["civitaiResources"])[0]["modelVersionId"] == 123

--- a/saver/test_video.py
+++ b/saver/test_video.py
@@ -10,6 +10,7 @@ from .video import (
     embed_video_metadata,
     escape_ffmetadata,
     native_video_metadata,
+    select_vhs_video_file,
     unpack_vhs_filenames,
 )
 
@@ -42,6 +43,25 @@ def test_escape_ffmetadata():
 def test_unpack_vhs_filenames():
     assert unpack_vhs_filenames((False, ["one.mp4", "two.webm"])) == (False, ["one.mp4", "two.webm"])
     assert unpack_vhs_filenames(["one.mp4"]) == (True, ["one.mp4"])
+
+
+def test_select_vhs_video_file_ignores_metadata_png():
+    files = ["AnimateDiff_00001.png", "AnimateDiff_00001.mp4"]
+    assert select_vhs_video_file(files) == "AnimateDiff_00001.mp4"
+
+
+def test_select_vhs_video_file_prefers_audio_muxed_output():
+    files = [
+        "AnimateDiff_00001.png",
+        "AnimateDiff_00001.mp4",
+        "AnimateDiff_00001-audio.mp4",
+    ]
+    assert select_vhs_video_file(files) == "AnimateDiff_00001-audio.mp4"
+
+
+def test_select_vhs_video_file_rejects_image_formats_clearly():
+    with pytest.raises(ValueError, match="no MP4 or WebM"):
+        select_vhs_video_file(["AnimateDiff_00001.png", "AnimateDiff_00001.gif"])
 
 
 def test_native_video_metadata_avoids_double_serializing_parameters():

--- a/saver/video.py
+++ b/saver/video.py
@@ -252,5 +252,28 @@ def unpack_vhs_filenames(value: Any) -> tuple[bool, list[str]]:
     raise TypeError("Expected the VHS_FILENAMES value returned by VideoHelperSuite.")
 
 
+def select_vhs_video_file(files: Iterable[str]) -> str:
+    """Return VHS's most complete supported video output.
+
+    VHS places its metadata PNG first, then the encoded video, and finally an
+    audio-muxed video when audio is connected. Its contract defines the last
+    entry as the most complete output, so search backward past image artifacts.
+    """
+    paths = [os.fspath(item) for item in files]
+    for path in reversed(paths):
+        if Path(path).suffix.lower() in {".mp4", ".webm"}:
+            return path
+
+    produced = ", ".join(
+        sorted({Path(path).suffix.lower() or "(no extension)" for path in paths})
+    )
+    detail = f" VHS produced: {produced}." if produced else ""
+    raise ValueError(
+        "Image Saver Video Metadata found no MP4 or WebM in the VHS output. "
+        "Choose a video/* MP4 or WebM format in Video Combine; image/gif and "
+        f"image/webp cannot carry this metadata.{detail}"
+    )
+
+
 def pack_vhs_filenames(save_output: bool, files: Iterable[str]) -> tuple[bool, list[str]]:
     return bool(save_output), list(files)

--- a/saver/video.py
+++ b/saver/video.py
@@ -1,0 +1,256 @@
+"""Video metadata helpers for Civitai-compatible Image Saver output."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+
+MAX_METADATA_VALUE_BYTES = 2 * 1024 * 1024
+
+
+def extract_json_after(text: str, marker: str) -> Any | None:
+    """Decode the first JSON value following ``marker``."""
+    if not text:
+        return None
+
+    marker_position = text.lower().find(marker.lower())
+    if marker_position < 0:
+        return None
+
+    payload = text[marker_position + len(marker):].lstrip()
+    try:
+        value, _ = json.JSONDecoder().raw_decode(payload)
+        return value
+    except json.JSONDecodeError:
+        return None
+
+
+def _json_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def native_video_metadata(tags: dict[str, str]) -> dict[str, Any]:
+    """Convert our FFmpeg-ready tags to values accepted by native VIDEO.
+
+    The native component encoder JSON-serializes every metadata value itself.
+    ``parameters`` is deliberately omitted here because it is an A1111 text
+    field and must be written as a raw container tag by the lossless remux
+    performed after the native encoder finishes.
+    """
+    native: dict[str, Any] = {}
+    for key, value in tags.items():
+        if key == "parameters":
+            continue
+        try:
+            native[key] = json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            native[key] = value
+    return native
+
+
+def build_video_metadata(
+    metadata: Any | None,
+    prompt: dict[str, Any] | None,
+    extra_pnginfo: dict[str, Any] | None,
+) -> dict[str, str]:
+    """Build the tags consumed by Civitai's proposed video metadata parser.
+
+    ``parameters`` remains the A1111-compatible source of positive/negative
+    prompts, settings, hashes, and Civitai resources. Structured tags preserve
+    the ComfyUI prompt/workflow and make the resource list available without
+    parsing the human-readable parameters string.
+    """
+    tags: dict[str, str] = {}
+
+    parameters = getattr(metadata, "a111_params", "") if metadata is not None else ""
+    if parameters:
+        tags["parameters"] = parameters
+
+    if prompt is not None:
+        tags["prompt"] = _json_value(prompt)
+
+    extra = dict(extra_pnginfo or {})
+    for key, value in extra.items():
+        tags[str(key)] = _json_value(value)
+
+    resources = extract_json_after(parameters, "Civitai resources:")
+    if resources is not None:
+        serialized_resources = _json_value(resources)
+        tags["civitaiResources"] = serialized_resources
+
+        # Keep this under the proposed generic metadata key too. This gives
+        # future readers a lossless structured fallback while parameters keeps
+        # compatibility with existing A1111/Civitai processors.
+        extra_metadata = None
+        if "extraMetadata" in tags:
+            try:
+                extra_metadata = json.loads(tags["extraMetadata"])
+            except json.JSONDecodeError:
+                pass
+        if isinstance(extra_metadata, dict):
+            extra_metadata.setdefault("civitaiResources", resources)
+            tags["extraMetadata"] = _json_value(extra_metadata)
+        elif "extraMetadata" not in tags:
+            tags["extraMetadata"] = _json_value({"civitaiResources": resources})
+
+    for key, value in list(tags.items()):
+        if len(value.encode("utf-8")) > MAX_METADATA_VALUE_BYTES:
+            raise ValueError(f"Video metadata field '{key}' exceeds the 2 MiB safety limit.")
+
+    return tags
+
+
+def escape_ffmetadata(value: str) -> str:
+    """Escape a value for FFmpeg's FFMETADATA1 format."""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace("#", "\\#")
+        .replace("=", "\\=")
+        .replace("\n", "\\\n")
+    )
+
+
+def write_ffmetadata(path: str | os.PathLike[str], tags: dict[str, str]) -> None:
+    with open(path, "w", encoding="utf-8", newline="\n") as metadata_file:
+        metadata_file.write(";FFMETADATA1\n")
+        for key, value in tags.items():
+            metadata_file.write(f"{escape_ffmetadata(key)}={escape_ffmetadata(value)}\n")
+
+
+def find_ffmpeg() -> str:
+    forced_path = os.environ.get("VHS_FORCE_FFMPEG_PATH") or os.environ.get("IMAGE_SAVER_FFMPEG_PATH")
+    if forced_path and os.path.isfile(forced_path):
+        return forced_path
+
+    ffmpeg = shutil.which("ffmpeg")
+    if ffmpeg:
+        return ffmpeg
+
+    try:
+        from imageio_ffmpeg import get_ffmpeg_exe
+
+        return get_ffmpeg_exe()
+    except Exception as error:
+        raise RuntimeError(
+            "Image Saver Video Metadata requires FFmpeg. Install FFmpeg or set "
+            "IMAGE_SAVER_FFMPEG_PATH to its executable."
+        ) from error
+
+
+def _output_path(source: Path, suffix: str, overwrite: bool) -> Path:
+    if overwrite:
+        return source
+
+    suffix = suffix or "_civitai"
+    candidate = source.with_name(f"{source.stem}{suffix}{source.suffix}")
+    counter = 1
+    while candidate.exists():
+        candidate = source.with_name(f"{source.stem}{suffix}_{counter}{source.suffix}")
+        counter += 1
+    return candidate
+
+
+def embed_video_metadata(
+    source: str | os.PathLike[str],
+    tags: dict[str, str],
+    suffix: str = "_civitai",
+    overwrite: bool = False,
+) -> str:
+    """Copy a video while adding container metadata, preserving all streams."""
+    source_path = Path(source)
+    if not source_path.is_file():
+        raise FileNotFoundError(f"Video file does not exist: {source_path}")
+
+    extension = source_path.suffix.lower()
+    if extension not in {".mp4", ".webm"}:
+        raise ValueError(f"Only MP4 and WebM videos are supported, got '{source_path.suffix}'.")
+
+    output_path = _output_path(source_path, suffix, overwrite)
+    temporary_output: Path | None = None
+    if overwrite:
+        temporary_file = tempfile.NamedTemporaryFile(
+            prefix=f"{source_path.stem}_",
+            suffix=source_path.suffix,
+            dir=source_path.parent,
+            delete=False,
+        )
+        temporary_file.close()
+        temporary_output = Path(temporary_file.name)
+        ffmpeg_output = temporary_output
+    else:
+        ffmpeg_output = output_path
+
+    metadata_file = tempfile.NamedTemporaryFile(
+        prefix="image_saver_video_metadata_",
+        suffix=".txt",
+        mode="w",
+        encoding="utf-8",
+        newline="\n",
+        delete=False,
+    )
+    metadata_file.close()
+
+    try:
+        write_ffmetadata(metadata_file.name, tags)
+        command = [
+            find_ffmpeg(),
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(source_path),
+            "-f",
+            "ffmetadata",
+            "-i",
+            metadata_file.name,
+            "-map",
+            "0",
+            "-map_metadata",
+            "1",
+            "-c",
+            "copy",
+        ]
+        if extension == ".mp4":
+            command.extend(["-movflags", "use_metadata_tags+faststart"])
+        command.append(str(ffmpeg_output))
+        subprocess.run(command, check=True, capture_output=True, text=True)
+
+        if overwrite and temporary_output is not None:
+            os.replace(temporary_output, source_path)
+        return str(output_path)
+    except subprocess.CalledProcessError as error:
+        details = (error.stderr or error.stdout or "").strip()
+        raise RuntimeError(f"FFmpeg could not write video metadata: {details}") from error
+    finally:
+        try:
+            os.remove(metadata_file.name)
+        except FileNotFoundError:
+            pass
+        if temporary_output is not None and temporary_output.exists():
+            temporary_output.unlink()
+
+
+def unpack_vhs_filenames(value: Any) -> tuple[bool, list[str]]:
+    """Accept the tuple returned by VideoHelperSuite's VHS_FILENAMES type."""
+    if isinstance(value, tuple) and len(value) == 2:
+        save_output, files = value
+        if isinstance(files, (list, tuple)):
+            return bool(save_output), [os.fspath(item) for item in files]
+    if isinstance(value, (list, tuple)):
+        return True, [os.fspath(item) for item in value]
+    raise TypeError("Expected the VHS_FILENAMES value returned by VideoHelperSuite.")
+
+
+def pack_vhs_filenames(save_output: bool, files: Iterable[str]) -> tuple[bool, list[str]]:
+    return bool(save_output), list(files)


### PR DESCRIPTION
## Summary

Add Civitai-compatible generation metadata support for video output through two explicit workflows:

- **Native ComfyUI VIDEO:** `Image Saver — Save Native Video (VIDEO + Audio)` saves native video values, including optional audio, and embeds Image Saver metadata.
- **VideoHelperSuite:** `Image Saver — Add Metadata to VHS Video` losslessly remuxes existing VHS MP4/WebM outputs and adds metadata without re-encoding streams.

Both paths write the existing A1111-compatible `parameters` text plus structured `prompt`, workflow/extra-info, `civitaiResources`, and `extraMetadata` tags.

## Motivation

Local video generation is now a common ComfyUI workflow, but Image Saver's prompt, hashes, and Civitai resource metadata were limited to still images. Civitai's native MP4/WebM metadata extraction is still pending in [civitai/civitai#3307](https://github.com/civitai/civitai/pull/3307).

The metadata written here is already usable through the optional, separate [Civitai Video Metadata Assistant](https://github.com/diodiogod/Civitai-Video-Metadata-Assistant). The extension is a compatibility bridge; it is not a dependency of Image Saver, and native Civitai detection remains the preferred future path.

## Implementation details

- Preserves the current Image Saver metadata contract, including prompts, settings, hashes, and Civitai resource identifiers.
- Supports MP4 and WebM container metadata through FFmpeg.
- Uses stream copy for VHS post-processing, preserving existing video and audio streams.
- Preserves the VHS source by default and writes a suffixed copy; overwrite mode uses a temporary output followed by atomic replacement.
- Uses ComfyUI's native VIDEO saver for frames plus optional audio, then performs a lossless metadata remux so text tags retain their expected representation.
- Supports Image Saver filename placeholders for native VIDEO output.
- Adds node descriptions, input tooltips, preview payloads, README documentation, and a changelog entry.
- Enforces a 2 MiB per-field safety limit.
- Uses the existing FFmpeg installation, VideoHelperSuite's configured FFmpeg path, or `IMAGE_SAVER_FFMPEG_PATH`.

## Tests

Run with the active ComfyUI Python environment from `saver/`:

```text
python -m pytest
```

Result: **45 passed**, including MP4 metadata remux/probe coverage when FFmpeg and FFprobe are available.

## Review notes

- No new Python dependency is introduced.
- The VHS node is intentionally labeled as a post-processor so it is not confused with the native VIDEO saver.
- This PR does not change existing image-saving behavior.